### PR TITLE
add #[cfg(feature = "use_serde")] to StorageIterate impl

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -298,6 +298,7 @@ where
     }
 }
 
+#[cfg(feature = "use_serde")]
 impl<const N: usize, R, S> StorageIterate for StorageImpl<N, R, S>
 where
     S: SerDe,


### PR DESCRIPTION
Serde was made optional in embedded-svc, so the StorageIterate impl needs to be configured to be built only when the use_serde feature is enabled.